### PR TITLE
Remove unsupported pstree options

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -23,7 +23,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-set +o posix
 
 #
 # Constant variables
@@ -182,7 +181,8 @@ _section_kernel_parameters()
 
 _section_pstree()
 {
-  _print_command_with_header /usr/bin/pstree -Uup
+  # Current busybox don't support -Uu options.
+  _print_command_with_header /usr/bin/pstree -p
 }
 
 _section_date()


### PR DESCRIPTION
Current busybox pstree don't support -Uu options. Remove also set +o posix line.