### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/sp-rich-core.spec
+++ b/rpm/sp-rich-core.spec
@@ -9,7 +9,7 @@ Source0: %{name}-%{version}.tar.gz
 BuildRequires: elfutils-libelf-devel
 BuildRequires: autoconf
 BuildRequires: gcc-c++
-BuildRequires: systemd
+BuildRequires: pkgconfig(systemd)
 Requires: sed
 Requires: coreutils
 Requires: lzop


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>