### PR TITLE
Unit test fixes. JB#57894 

### DIFF
--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -292,16 +292,6 @@ _section_repositories()
 
 _dump_logs()
 {
-  for xorglog in /var/log/Xorg.0.log.*.gz; do
-    if [ -f "$xorglog" ]; then
-      _print_header $xorglog
-      zcat $xorglog
-    fi
-  done
-
-  _print_file_with_header /var/log/Xorg.0.log
-  _print_file_with_header /var/log/Xorg.0.log.old
-
   _print_command_with_header /usr/bin/journalctl -b
   _print_command_with_header /bin/dmesg
 

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -655,8 +655,8 @@ fi
 # alternatives if this is not the case.
 
 if [ "${core_pid}" -gt 0 ]; then
-core_tmp=`tr '\0' ' ' < /proc/${core_pid}/cmdline | cut -d' ' -f1`
-core_name=${core_tmp##*/}
+  core_tmp=`tr '\0' ' ' < /proc/${core_pid}/cmdline | cut -d' ' -f1`
+  core_name=${core_tmp##*/}
 fi
 
 if [ -z "${core_name}" ]; then
@@ -771,7 +771,7 @@ if [ "${core_name}" = "OneshotFailure" ]; then
   _section_failed_oneshot_scripts
 fi
 if [ x"$NO_SECTION_HEADER" = x"true" ] && [ "${omit_core}" != "true" ]; then
-cat
+  cat
 elif [ -n "${IS_OOPSLOG}" ]; then
   _print_header oopslog
   cat

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -681,7 +681,7 @@ fi
 # on white/blacklisting rules.
 
 if [ -e /etc/rich-core.include ]; then
-    /bin/grep -q "^[[:space:]]*${core_name}[[:space:]]*$" /etc/rich-core.include
+    grep -q "^[[:space:]]*${core_name}[[:space:]]*$" /etc/rich-core.include
     if [ $? -ne 0 ]; then
         # Not in the whitelist; do not dump a core
         cat > /dev/null
@@ -689,7 +689,7 @@ if [ -e /etc/rich-core.include ]; then
     fi
 fi
 if [ -e /etc/rich-core.exclude ]; then
-    /bin/grep -q "^[[:space:]]*${core_name}[[:space:]]*$" /etc/rich-core.exclude
+    grep -q "^[[:space:]]*${core_name}[[:space:]]*$" /etc/rich-core.exclude
     if [ $? -eq 0 ]; then
         # Is in the blacklist; do not dump a core
         cat > /dev/null

--- a/tests/test_whiteblacklist
+++ b/tests/test_whiteblacklist
@@ -85,36 +85,36 @@ EOF
 }
 
 _run_test_case() {
-    cat $COMMANDS_FILE | while read cmd
-    do
-	EXE=$(basename ${cmd%% *})
-	$cmd&
-	PID=$!
+  cat $COMMANDS_FILE | while read cmd
+  do
+ 	EXE=$(basename ${cmd%% *})
+ 	$cmd&
+ 	PID=$!
 
-	sleep 1
-        # send signal causing core dump and wait rich core to be created
-	kill -11 $PID
-	sleep 5
+ 	sleep 1
+ 	# send signal causing core dump and wait rich core to be created
+ 	kill -11 $PID
+ 	sleep 5
 	
 	if ls $CORE_DUMPS_DIR | grep -qe "$EXE-.*-$PID\.rcore\.lzo"; then
-	    if [ "$EXPECTED_CORE" -eq 1 ]; then
+	  if [ "$EXPECTED_CORE" == "1" ]; then
 		echo "PASSED: command $cmd"
-	    else
+	  else
 		echo "FAILED: command $cmd" >&2
 		touch /tmp/richcoretest_failed
-	    fi
+	  fi
 	else
-	    if [ "$EXPECTED_CORE" -eq 0 ]; then
+	  if [ "$EXPECTED_CORE" == "0" ]; then
 		echo "PASSED: command $cmd"
-	    else
+	  else
 		echo "FAILED: command $cmd" >&2
 		touch /tmp/richcoretest_failed
-	    fi
+ 	  fi
 	fi
 
-        # cleanup (possible) core
+	# cleanup (possible) core
 	rm -f $CORE_DUMPS_DIR/$EXE*$PID.rcore.lzo
-    done
+  done
 }
 
 #

--- a/tests/test_whiteblacklist
+++ b/tests/test_whiteblacklist
@@ -94,7 +94,7 @@ _run_test_case() {
  	sleep 1
  	# send signal causing core dump and wait rich core to be created
  	kill -11 $PID
- 	sleep 5
+ 	sleep 30
 	
 	if ls $CORE_DUMPS_DIR | grep -qe "$EXE-.*-$PID\.rcore\.lzo"; then
 	  if [ "$EXPECTED_CORE" == "1" ]; then
@@ -140,6 +140,7 @@ if [ -e "$BLACKLIST_FILE" ]; then
     mv $BLACKLIST_FILE $BLACKLIST_FILE_BAK
 fi
 
+echo "Starting white / black list test. Make sure you have crash report autoupload disabled"
 echo "Running case 1"
 _setup_case1
 _run_test_case

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -2,7 +2,7 @@
 <testdefinition version="1.0">
     <suite name="core-reducer-tests" domain="Core">
         <description>Testing of sp-rich-core</description>
-        <set name="Installation-acceptance-tests" feature="Integration">
+        <set name="Installation-acceptance-tests" feature="sp-rich-core">
             <description>Ensure the application is installed correctly</description>
             <environments>
               <scratchbox>false</scratchbox>
@@ -32,9 +32,6 @@
             <case name="Rich-core-extract-test" type="Integration" level="Feature">
               <step expected_result="0">/usr/sbin/run-root /usr/share/sp-rich-core-tests/test_extract</step>
             </case>
-	</set>
-        <set name="input-validation-tests" feature="Robustness">
-            <description>Determine how the application responds to input</description>
             <case name="no-parameters" type="Robustness" level="Component">
                 <step expected_result="255">core-reducer</step>
             </case>


### PR DESCRIPTION
Seems like the whiteblacklist test failures were mostly just about the amount of sleep to let core dumper do all sorts of PackageKit things etc. Hope this is now enough.

Fixes all sorts of other defails I noticed while hunting this.

@Tomin1 @llewelld @spiiroin 