### PR TITLE
Support saving core dumps to home partition. JB#63284

### DIFF
--- a/core-reducer/procinterface.cpp
+++ b/core-reducer/procinterface.cpp
@@ -63,7 +63,7 @@ ADDRESS ProcInterface::heapAddress(const char *fileName) const
                 {
                     // correct line is found
                     ADDRESS addr = 0;
-                    if(sscanf(buf, "%x", &addr)>0)
+                    if(sscanf(buf, "%lx", &addr)>0)
                     {
                         fclose(fd);
                         return addr;
@@ -115,7 +115,7 @@ const std::vector<ProcInterface::SharedObject> *ProcInterface::getSharedObjects(
                 {
                     // correct line is found - get needed data
                     ADDRESS addr = 0;
-                    sscanf(buf, "%x", &addr);
+                    sscanf(buf, "%lx", &addr);
                     int len = strlen(buf);
                     if (len > 0)
                     {

--- a/core-reducer/rawelfwriter.cpp
+++ b/core-reducer/rawelfwriter.cpp
@@ -222,12 +222,12 @@ ADDRESS RawElfWriter::createR_DebugStruct()
 ADDRESS RawElfWriter::addR_DebugStruct(const char *rDebugStart)
 {
     if (!rDebugStart)
-        return NULL;
+        return 0;
 
     if ((R_DEBUG_STRUCT_SIZE + offset) > currentBufferSize)
     {
         if (!reallocate(R_DEBUG_STRUCT_SIZE + offset + LM_BUFFER_DATA_SIZE))
-            return NULL;
+            return 0;
     }
 
     char *writePointer = buffer + offset;
@@ -268,7 +268,7 @@ ADDRESS RawElfWriter::createAndAddLinkMapSegment(ADDRESS memoryAddress, const ch
 ADDRESS RawElfWriter::addLinkMapSegment(const char *linkMapStart, const char *stringStart)
 {
     if (!linkMapStart)
-        return NULL;
+        return 0;
 
     LinkMap *LM_To_Copy = (LinkMap *)linkMapStart;
 
@@ -281,7 +281,7 @@ ADDRESS RawElfWriter::addLinkMapSegment(const char *linkMapStart, const char *st
     if ((sizeof(LinkMap) + stringSize + offset) > currentBufferSize)
     {
         if (!reallocate(sizeof(LinkMap) + stringSize + offset + LM_BUFFER_DATA_SIZE))
-            return NULL;
+            return 0;
     }
 
     //write the link map information
@@ -380,7 +380,7 @@ bool RawElfWriter::write()
 void RawElfWriter::close()
 {
     if (fd)
-    {   
+    {
         ::close(fd);
         fd = -1;
     }

--- a/core-reducer/reducer.cpp
+++ b/core-reducer/reducer.cpp
@@ -67,15 +67,15 @@ Reducer::Reducer(const char *output, ADDRESS heap)
     :   coreReader(NULL),
     binaryReader(NULL),
     coreWriter(NULL),
-    dynamicAddressFromExecutable(NULL),
+    dynamicAddressFromExecutable(0),
     dynamicSectionSizeFromExecutable(0),
-    interpAddress(NULL),
+    interpAddress(0),
     interpreter(NULL),
     output(output),
     heapAddress(heap),
     processId(INT_MAX),
     executableName(NULL),
-	phdrAddr(0)
+    phdrAddr(0)
 {
 }
 
@@ -129,8 +129,8 @@ bool Reducer::initalize(const char *core, const char *binary)
     if (!binaryReader->initalize(binary))
         return false;
 
-	Phdr *phdr = binaryReader->getSegmentByType(PT_PHDR);
-	ADDRESS loadBias = phdrAddr - phdr->p_vaddr;
+    Phdr *phdr = binaryReader->getSegmentByType(PT_PHDR);
+    ADDRESS loadBias = phdrAddr - phdr->p_vaddr;
     //get the dynamic section from the binary executable
     const CurrentSectionData *binarySectionData = binaryReader->getSectionByType(SHT_DYNAMIC);
     if (binarySectionData)
@@ -243,19 +243,19 @@ bool Reducer::getNotes()
             //but not just the name it should include its path
             executableName = info->pr_psargs;
         }
-		else if (current->n_type == NT_AUXV)
-		{
-			Auxv *aux = (Auxv *)((char *)(current + 1) + align_power(current->n_namesz, 2)); 
-			while (aux->a_type != AT_NULL)
-			{
-				if (aux->a_type == AT_PHDR)
-				{
-					phdrAddr = (ADDRESS)aux->a_un.a_val;
-					break; 
-				}
-				++aux;
-			}
-		}
+        else if (current->n_type == NT_AUXV)
+        {
+            Auxv *aux = (Auxv *)((char *)(current + 1) + align_power(current->n_namesz, 2));
+            while (aux->a_type != AT_NULL)
+            {
+                if (aux->a_type == AT_PHDR)
+                {
+                    phdrAddr = (ADDRESS)aux->a_un.a_val;
+                    break;
+                }
+                ++aux;
+            }
+        }
 
         current = (Nhdr *)((char *)(current + 1) + align_power (current->n_namesz, 2)
                            + align_power (current->n_descsz, 2));

--- a/rpm/sp-rich-core.spec
+++ b/rpm/sp-rich-core.spec
@@ -32,17 +32,6 @@ Requires: systemd
 %description
 Tool that creates rich core dumps, which include information about system state and core in a single compressed file. Requires a kernel that supports piping core dumps.
 
-%files
-%defattr(-,root,root,-)
-%license COPYING
-%{_unitdir}/rich-core-early-collect.service
-%{_unitdir}/graphical.target.wants/rich-core-early-collect.service
-/usr/lib/sysctl.d/sp-rich-core.conf
-%{_sbindir}/rich-core-dumper
-%{_libexecdir}/rich-core-check-oneshot
-/usr/lib/startup/preinit/late.d/rich-core-preinit
-/var/cache/core-dumps
-
 %package postproc
 Summary: Rich core postprocessing
 Requires: lzop
@@ -50,10 +39,6 @@ Requires: gzip
 
 %description postproc
 Tools to extract information from rich cores.
-
-%files postproc
-%defattr(-,root,root,-)
-%{_bindir}/rich-core-extract
 
 %package tests
 Summary: Tests for the sp-rich-core packages
@@ -67,10 +52,6 @@ Requires: nemo-test-tools
 %description tests
 Provides test cases for sp-rich-core, sp-rich-core-postproc and core-reducer.
 
-%files tests
-%defattr(-,root,root,-)
-%{_datadir}/%{name}-tests/*
-
 %package -n core-reducer
 Summary: Reduce the size of a core dump
 Requires: %{name} = %{version}-%{release}
@@ -79,20 +60,11 @@ Requires: elfutils-libelf
 %description -n core-reducer
 Create core dumps that have a reduced size, allowing them to be transported between systems, even those with limited network throughput.
 
-%files -n core-reducer
-%defattr(-,root,root,-)
-%{_bindir}/core-reducer
-
 %package -n gdb-qml-stacktrace
 Summary: Allows inspecting QML stack traces in gdb
 
 %description -n gdb-qml-stacktrace
 A gdb frame filter that prints a QML stack trace in addition to a regular backtrace of a Qt/QML application.
-
-%files -n gdb-qml-stacktrace
-%defattr(-,root,root,-)
-%config %{_sysconfdir}/gdbinit.d/*
-%{_datadir}/gdb/python/gdb/*
 
 %prep
 %setup -q
@@ -121,3 +93,27 @@ make distclean
 if [ "$1" = 0 ]; then
   rm -f /var/cache/core-dumps/*.tmp /var/cache/core-dumps/oneshots
 fi
+
+%files
+%license COPYING
+%{_unitdir}/rich-core-early-collect.service
+%{_unitdir}/graphical.target.wants/rich-core-early-collect.service
+/usr/lib/sysctl.d/sp-rich-core.conf
+%{_sbindir}/rich-core-dumper
+%{_libexecdir}/rich-core-check-oneshot
+/usr/lib/startup/preinit/late.d/rich-core-preinit
+/var/cache/core-dumps
+
+%files postproc
+%{_bindir}/rich-core-extract
+
+%files tests
+%{_datadir}/%{name}-tests/*
+
+%files -n core-reducer
+%{_bindir}/core-reducer
+
+%files -n gdb-qml-stacktrace
+%config %{_sysconfdir}/gdbinit.d/*
+%{_datadir}/gdb/python/gdb/*
+

--- a/scripts/rich-core-check-oneshot
+++ b/scripts/rich-core-check-oneshot
@@ -12,22 +12,22 @@ PREVIOUS_ONESHOTS=$(mktemp /tmp/previous_oneshots.XXXXXX)
 cat $ONESHOTS_FILE >> $PREVIOUS_ONESHOTS
 
 echo "$ONESHOTS" | while read oneshot; do
-	is_new=1
-	while read oldshot; do
-		if [ "$oneshot" = "$oldshot" ]; then
-			is_new=0
-			break
-		fi
-	done < $PREVIOUS_ONESHOTS
-	if [ $is_new -eq 1 ]; then
-		logger "Found failed oneshot script; dumping log files."
-		echo "${ONESHOTS}" > "$ONESHOTS_FILE"
-		# Don't set failure, if oneshot line is empty.
-		if [ ${#oneshot} != 0 ]; then
-			/usr/sbin/rich-core-dumper --name=OneshotFailure --signal=$RANDOM
-		fi
-		break
-	fi
+  is_new=1
+  while read oldshot; do
+    if [ "$oneshot" = "$oldshot" ]; then
+      is_new=0
+      break
+    fi
+  done < $PREVIOUS_ONESHOTS
+  if [ $is_new -eq 1 ]; then
+    logger "Found failed oneshot script; dumping log files."
+    echo "${ONESHOTS}" > "$ONESHOTS_FILE"
+    # Don't set failure, if oneshot line is empty.
+    if [ ${#oneshot} != 0 ]; then
+      /usr/sbin/rich-core-dumper --name=OneshotFailure --signal=$RANDOM
+    fi
+    break
+  fi
 done
 
 rm $PREVIOUS_ONESHOTS

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -42,7 +42,7 @@ _read_config_variable()
   value=$2
   for file in $user_settings/$config_file $system_settings/$config_file; do
     if [ -e $file ]; then
-      v=$(awk -F "=" "/$1/ {print \$2}" $file)
+      v=$(awk -F "=" "/^$1=/ {print \$2}" $file)
       if [ "$v" != "" ]; then
         value=$v
         break

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -40,19 +40,15 @@ WAKE_LOCK_TIMEOUT=120 # s
 _read_config_variable()
 {
   value=$2
-  if [ -e $system_settings/crash-reporter-privacy.conf ]; then
-    v=$(awk -F "=" "/$1/ {print \$2}" $system_settings/crash-reporter-privacy.conf)
-    if [ "$v" != "" ]; then
-      value=$v
+  for file in $user_settings/$config_file $system_settings/$config_file; do
+    if [ -e $file ]; then
+      v=$(awk -F "=" "/$1/ {print \$2}" $file)
+      if [ "$v" != "" ]; then
+        value=$v
+        break
+      fi
     fi
-  fi
-
-  if [ -e $user_settings/crash-reporter-privacy.conf ]; then
-    v=$(awk -F "=" "/$1/ {print \$2}" $user_settings/crash-reporter-privacy.conf)
-    if [ "$v" != "" ]; then
-      value=$v
-    fi
-  fi
+  done
 
   echo $value
 }
@@ -61,6 +57,7 @@ _obtain_configuration()
 {
   # default fallback values, overruled by configuration file if one exists
 
+  config_file=crash-reporter-privacy.conf
   system_settings=/usr/share/crash-reporter-settings
   system_user=$(getent group sailfish-system | cut -d: -f4 | tr , '\n' | grep -vE '^sailfish-' | head -n1)
   user_settings=$(getent passwd ${system_user} | cut -d: -f6)/.config/crash-reporter-settings

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -30,7 +30,7 @@
 
 SW_VERSION_FILE=/etc/os-release
 CORE_LOCATION=/var/cache/core-dumps
-CORE_REDUCE_THRESHOLD=10000	# kB
+CORE_REDUCE_THRESHOLD=10000 # kB
 WAKE_LOCK_TIMEOUT=120 # s
 
 #
@@ -39,7 +39,7 @@ WAKE_LOCK_TIMEOUT=120 # s
 
 _read_config_variable()
 {
-  value=$2 
+  value=$2
   if [ -e $system_settings/crash-reporter-privacy.conf ]; then
     v=$(awk -F "=" "/$1/ {print \$2}" $system_settings/crash-reporter-privacy.conf)
     if [ "$v" != "" ]; then
@@ -68,7 +68,7 @@ _obtain_configuration()
 
   coredumping=$(_read_config_variable coredumping true)
   privacy_notice_accepted=$(_read_config_variable privacy-notice-accepted true)
-  
+
   INCLUDE_CORE=$(_read_config_variable INCLUDE_CORE true)
   # Core size limit in kB, or 0 for unlimited (except by free disk space)
   CORE_SIZE_LIMIT=$(_read_config_variable CORE_SIZE_LIMIT 1000000)
@@ -85,16 +85,16 @@ _obtain_configuration()
 _parse_arguments()
 {
   while [ $# -ge 1 ]; do
-    case $1 in 
+    case $1 in
       "--no-section-header")
       NO_SECTION_HEADER=true
       ;;
       "--default-name")
-			shift
+      shift
       DEFAULT_CORE_NAME="$1"
       ;;
       --pid=*)
-      core_pid=${1#--pid=}     
+      core_pid=${1#--pid=}
       ;;
       --signal=*)
       core_sig=${1#--signal=}
@@ -510,7 +510,7 @@ _download_debuginfo()
     _log_rich_core_error "No suitable connection, not downloading debuginfo"
     return 1
   fi
-  
+
   _print_header debuginfo_download
   pkcon -p -y refresh; echo $LIBS | xargs rpm -qf | sed -e 's/-[^-]*-[^-]*$/-debuginfo/' | xargs pkcon -p -y install
 }
@@ -572,7 +572,7 @@ _run_with_timeout()
 
   if wait $watcher; then
     # $watcher process returns zero exit status if timeout did occur.
-    echo "$cmd terminated after $timeout seconds." 
+    echo "$cmd terminated after $timeout seconds."
   fi
 }
 
@@ -749,7 +749,7 @@ hwid=$(ssu-sysinfo -m 2> /dev/null)
 if [ -z "${hwid}" ]; then
   hwid="xxx"
 fi
- 
+
 # Make a naming distinction between oopslogs and rich-cores
 if [ -n "${IS_OOPSLOG}" ]; then
   timestamp=$(date +%F-%S)

--- a/scripts/rich-core-dumper
+++ b/scripts/rich-core-dumper
@@ -29,7 +29,6 @@
 #
 
 SW_VERSION_FILE=/etc/os-release
-CORE_LOCATION=/var/cache/core-dumps
 CORE_REDUCE_THRESHOLD=10000 # kB
 WAKE_LOCK_TIMEOUT=120 # s
 
@@ -65,6 +64,20 @@ _obtain_configuration()
 
   coredumping=$(_read_config_variable coredumping true)
   privacy_notice_accepted=$(_read_config_variable privacy-notice-accepted true)
+
+  use_home_partition=$(_read_config_variable use-home-partition false)
+  home_mounted=$(grep " /home " /etc/mtab | wc -l)
+  if [ "$use_home_partition" == "true" ] && [ $home_mounted -eq 1 ]; then
+    CORE_LOCATION="/home/.crash-reporter/core-dumps"
+    if [ ! -d "$CORE_LOCATION" ]; then
+      mkdir -p "$CORE_LOCATION"
+      chmod 777 "$CORE_LOCATION"
+    fi
+  else
+    CORE_LOCATION="/var/cache/core-dumps"
+  fi
+  unset use_home_partition
+  unset home_mounted
 
   INCLUDE_CORE=$(_read_config_variable INCLUDE_CORE true)
   # Core size limit in kB, or 0 for unlimited (except by free disk space)
@@ -338,7 +351,7 @@ _dump_panic_partition()
 _section_failed_oneshot_scripts()
 {
   _print_header failed_oneshot_scripts
-  cat "${CORE_LOCATION}/oneshots"
+  cat "/var/cache/core-dumps/oneshots"
 }
 
 _section_rich_core_errors()
@@ -758,10 +771,12 @@ fi
 rcorefilename=${rcorebasename}.rcore.lzo
 
 # Create marker file for testrunner-lite
-if [ -f "${CORE_LOCATION}/testrunner-lite-testcase" ]; then
-  core_tc_uuid=$(cat "${CORE_LOCATION}/testrunner-lite-testcase")
+testcase_file="/var/cache/core-dumps/testrunner-lite-testcase"
+if [ -f "$testcase_file" ]; then
+  core_tc_uuid=$(cat "$testcase_file")
   touch "${rcorefilename}.${core_tc_uuid}"
 fi
+unset testcase_file
 
 # Collect process specific information first, only then system
 # as process may disappear while this info is collected

--- a/tests/test_extra_files
+++ b/tests/test_extra_files
@@ -6,329 +6,329 @@ ret=0
 
 test_case_1()
 {
-    cat > /tmp/foo.txt <<EOF
+  cat > /tmp/foo.txt <<EOF
 abc
 def
 EOF
 
-    cat > /tmp/bar.txt <<EOF
+  cat > /tmp/bar.txt <<EOF
 0123456789
 EOF
 
-    cat > /tmp/default.txt <<EOF
+  cat > /tmp/default.txt <<EOF
 rich-core test file
 EOF
 
-    cat > ${EXTRAS_FILE} <<EOF
+  cat > ${EXTRAS_FILE} <<EOF
 /tmp/foo.txt
 /tmp/bar.txt
 EOF
 
-    cat > ${DEFAULT_EXTRAS_FILE} <<EOF
+  cat > ${DEFAULT_EXTRAS_FILE} <<EOF
 /tmp/default.txt
 EOF
 
-    rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
-    rm -fr ./outputdir
+  rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
+  rm -fr ./outputdir
 
-    sleep 60&
-    PID=$!
-    echo "started sleep process with PID $PID"
-    sleep 1
-    kill -SEGV ${PID}
-    wait ${PID}
-    sleep 5
+  sleep 60&
+  PID=$!
+  echo "started sleep process with PID $PID"
+  sleep 1
+  kill -SEGV ${PID}
+  wait ${PID}
+  sleep 5
 
-    if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
-	if [ ! -f ./outputdir/foo.txt ]; then
-	    echo "ERROR: file foo.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
-	    echo "ERROR: contents of file foo.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/bar.txt ]; then
-	    echo "ERROR: file bar.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/bar.txt ./outputdir/bar.txt; then
-	    echo "ERROR: contents of file bar.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/default.txt ]; then
-	    echo "ERROR: file default.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/default.txt ./outputdir/default.txt; then
-	    echo "ERROR: contents of file default.txt in rich core does not match the original"
-	    return 1
-	fi
-    else
-	echo "ERROR: rich-core-extract failed"
-	return 1
+  if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
+    if [ ! -f ./outputdir/foo.txt ]; then
+      echo "ERROR: file foo.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
+      echo "ERROR: contents of file foo.txt in rich core does not match the original"
+      return 1
     fi
 
-    return 0
+    if [ ! -f ./outputdir/bar.txt ]; then
+      echo "ERROR: file bar.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/bar.txt ./outputdir/bar.txt; then
+      echo "ERROR: contents of file bar.txt in rich core does not match the original"
+      return 1
+    fi
+
+    if [ ! -f ./outputdir/default.txt ]; then
+      echo "ERROR: file default.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/default.txt ./outputdir/default.txt; then
+      echo "ERROR: contents of file default.txt in rich core does not match the original"
+      return 1
+    fi
+  else
+    echo "ERROR: rich-core-extract failed"
+    return 1
+  fi
+
+  return 0
 }
 
 test_case_2()
 {
-    cat > /tmp/foo.txt <<EOF
+  cat > /tmp/foo.txt <<EOF
 abc
 def
 EOF
 
-    cat > /tmp/bar.txt <<EOF
+  cat > /tmp/bar.txt <<EOF
 0123456789
 EOF
 
-    cat > /tmp/default.txt <<EOF
+  cat > /tmp/default.txt <<EOF
 rich-core test file
 EOF
 
-    cat > ${EXTRAS_FILE} <<EOF
+  cat > ${EXTRAS_FILE} <<EOF
 /tmp/foo.txt
 /tmp/bar.txt
 EOF
 
-    rm -f ${DEFAULT_EXTRAS_FILE}
+  rm -f ${DEFAULT_EXTRAS_FILE}
 
-    rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
-    rm -fr ./outputdir
+  rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
+  rm -fr ./outputdir
 
-    sleep 60&
-    PID=$!
-    echo "started sleep process with PID $PID"
-    sleep 1
-    kill -SEGV ${PID}
-    wait ${PID}
-    sleep 5
+  sleep 60&
+  PID=$!
+  echo "started sleep process with PID $PID"
+  sleep 1
+  kill -SEGV ${PID}
+  wait ${PID}
+  sleep 5
 
-    if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
-	if [ ! -f ./outputdir/foo.txt ]; then
-	    echo "ERROR: file foo.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
-	    echo "ERROR: contents of file foo.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/bar.txt ]; then
-	    echo "ERROR: file bar.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/bar.txt ./outputdir/bar.txt; then
-	    echo "ERROR: contents of file bar.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ -f ./outputdir/default.txt ]; then
-	    echo "ERROR: file default.txt should not be included in rich core"
-	    return 1
-	fi
-    else
-	echo "ERROR: rich-core-extract failed"
-	return 1
+  if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
+    if [ ! -f ./outputdir/foo.txt ]; then
+      echo "ERROR: file foo.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
+      echo "ERROR: contents of file foo.txt in rich core does not match the original"
+      return 1
     fi
 
-    return 0
+    if [ ! -f ./outputdir/bar.txt ]; then
+      echo "ERROR: file bar.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/bar.txt ./outputdir/bar.txt; then
+      echo "ERROR: contents of file bar.txt in rich core does not match the original"
+      return 1
+    fi
+
+    if [ -f ./outputdir/default.txt ]; then
+      echo "ERROR: file default.txt should not be included in rich core"
+      return 1
+    fi
+  else
+    echo "ERROR: rich-core-extract failed"
+    return 1
+  fi
+
+  return 0
 }
 
 test_case_3()
 {
-    cat > /tmp/foo.txt <<EOF
+  cat > /tmp/foo.txt <<EOF
 abc
 def
 EOF
 
-    rm -f /tmp/bar.txt
+  rm -f /tmp/bar.txt
 
-    cat > /tmp/default.txt <<EOF
+  cat > /tmp/default.txt <<EOF
 rich-core test file
 EOF
 
-    cat > ${EXTRAS_FILE} <<EOF
+  cat > ${EXTRAS_FILE} <<EOF
 /tmp/foo.txt
 /tmp/bar.txt
 EOF
 
-    cat > ${DEFAULT_EXTRAS_FILE} <<EOF
+  cat > ${DEFAULT_EXTRAS_FILE} <<EOF
 /tmp/default.txt
 EOF
 
-    rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
-    rm -fr ./outputdir
+  rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
+  rm -fr ./outputdir
 
-    sleep 60&
-    PID=$!
-    echo "started sleep process with PID $PID"
-    sleep 1
-    kill -SEGV ${PID}
-    wait ${PID}
-    sleep 5
+  sleep 60&
+  PID=$!
+  echo "started sleep process with PID $PID"
+  sleep 1
+  kill -SEGV ${PID}
+  wait ${PID}
+  sleep 5
 
-    if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
-	if [ ! -f ./outputdir/foo.txt ]; then
-	    echo "ERROR: file foo.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
-	    echo "ERROR: contents of file foo.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ -f ./outputdir/bar.txt ]; then
-	    echo "ERROR: file bar.txt should not be included in rich core"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/default.txt ]; then
-	    echo "ERROR: file default.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/default.txt ./outputdir/default.txt; then
-	    echo "ERROR: contents of file default.txt in rich core does not match the original"
-	    return 1
-	fi
-    else
-	echo "ERROR: rich-core-extract failed"
-	return 1
+  if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
+    if [ ! -f ./outputdir/foo.txt ]; then
+      echo "ERROR: file foo.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
+      echo "ERROR: contents of file foo.txt in rich core does not match the original"
+      return 1
     fi
 
-    return 0
+    if [ -f ./outputdir/bar.txt ]; then
+      echo "ERROR: file bar.txt should not be included in rich core"
+      return 1
+    fi
+
+    if [ ! -f ./outputdir/default.txt ]; then
+      echo "ERROR: file default.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/default.txt ./outputdir/default.txt; then
+      echo "ERROR: contents of file default.txt in rich core does not match the original"
+      return 1
+    fi
+  else
+    echo "ERROR: rich-core-extract failed"
+    return 1
+  fi
+
+  return 0
 }
 
 test_case_4()
 {
-    rm -f ${EXTRAS_FILE}
-    rm -f ${DEFAULT_EXTRAS_FILE}
+  rm -f ${EXTRAS_FILE}
+  rm -f ${DEFAULT_EXTRAS_FILE}
 
-    rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
-    rm -fr ./outputdir
+  rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
+  rm -fr ./outputdir
 
-    sleep 60&
-    PID=$!
-    echo "started sleep process with PID $PID"
-    sleep 1
-    kill -SEGV ${PID}
-    wait ${PID}
-    sleep 5
+  sleep 60&
+  PID=$!
+  echo "started sleep process with PID $PID"
+  sleep 1
+  kill -SEGV ${PID}
+  wait ${PID}
+  sleep 5
 
-    if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
-	if [ ! -f ./outputdir/cmdline ]; then
-	    echo "ERROR: file cmdline is missing from rich core"
-	    return 1
-	fi
-    else
-	echo "ERROR: rich-core-extract failed"
-	return 1
+  if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
+    if [ ! -f ./outputdir/cmdline ]; then
+      echo "ERROR: file cmdline is missing from rich core"
+      return 1
     fi
+  else
+    echo "ERROR: rich-core-extract failed"
+    return 1
+  fi
 
-    return 0
+  return 0
 }
 
 test_case_5()
 {
-    cat > /tmp/foo.txt <<EOF
+  cat > /tmp/foo.txt <<EOF
 abc
 def
 EOF
 
-    cat > /tmp/bar.txt <<EOF
+  cat > /tmp/bar.txt <<EOF
 0123456789
 EOF
 
-    cat > /tmp/bar.log <<EOF
+  cat > /tmp/bar.log <<EOF
 log file
 EOF
 
-    cat > /tmp/default.txt <<EOF
+  cat > /tmp/default.txt <<EOF
 rich-core test file
 EOF
 
-    cat > /tmp/default.foobar <<EOF
+  cat > /tmp/default.foobar <<EOF
 default foobar file
 for rich-core testing
 contains several lines :)
 EOF
 
-    cat > ${EXTRAS_FILE} <<EOF
+  cat > ${EXTRAS_FILE} <<EOF
 /tmp/foo.txt
 /no/such/file
 /tmp/bar.*
 EOF
 
-    cat > ${DEFAULT_EXTRAS_FILE} <<EOF
+  cat > ${DEFAULT_EXTRAS_FILE} <<EOF
 /tmp/default.txt
 /tmp/*.foobar
 nosuchfiles*
 /tmp/default.*.gz
 EOF
 
-    tar czf /tmp/default.foobar.tar.gz /tmp/default.foobar
+  tar czf /tmp/default.foobar.tar.gz /tmp/default.foobar
 
-    rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
-    rm -fr ./outputdir
+  rm -f /var/cache/core-dumps/sleep-*.rcore.lzo
+  rm -fr ./outputdir
 
-    sleep 60&
-    PID=$!
-    echo "started sleep process with PID $PID"
-    sleep 1
-    kill -SEGV ${PID}
-    wait ${PID}
-    sleep 5
+  sleep 60&
+  PID=$!
+  echo "started sleep process with PID $PID"
+  sleep 1
+  kill -SEGV ${PID}
+  wait ${PID}
+  sleep 5
 
-    if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
-	if [ ! -f ./outputdir/foo.txt ]; then
-	    echo "ERROR: file foo.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
-	    echo "ERROR: contents of file foo.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/bar.txt ]; then
-	    echo "ERROR: file bar.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/bar.txt ./outputdir/bar.txt; then
-	    echo "ERROR: contents of file bar.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/bar.log ]; then
-	    echo "ERROR: file bar.log is missing from rich core"
-	    return 1
-	elif ! diff /tmp/bar.log ./outputdir/bar.log; then
-	    echo "ERROR: contents of file bar.log in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/default.txt ]; then
-	    echo "ERROR: file default.txt is missing from rich core"
-	    return 1
-	elif ! diff /tmp/default.txt ./outputdir/default.txt; then
-	    echo "ERROR: contents of file default.txt in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/default.foobar ]; then
-	    echo "ERROR: file default.foobar is missing from rich core"
-	    return 1
-	elif ! diff /tmp/default.foobar ./outputdir/default.foobar; then
-	    echo "ERROR: contents of file default.foobar in rich core does not match the original"
-	    return 1
-	fi
-
-	if [ ! -f ./outputdir/default.foobar.tar.gz ]; then
-	    echo "ERROR: file default.foobar.tar.gz is missing from rich core"
-	    return 1
-	elif ! diff /tmp/default.foobar.tar.gz ./outputdir/default.foobar.tar.gz; then
-	    echo "ERROR: contents of file default.foobar.tar.gz in rich core does not match the original"
-	    return 1
-	fi
-    else
-	echo "ERROR: rich-core-extract failed"
-	return 1
+  if rich-core-extract /var/cache/core-dumps/sleep-*-${PID}.rcore.lzo outputdir; then
+    if [ ! -f ./outputdir/foo.txt ]; then
+      echo "ERROR: file foo.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/foo.txt ./outputdir/foo.txt; then
+      echo "ERROR: contents of file foo.txt in rich core does not match the original"
+      return 1
     fi
 
-    return 0
+    if [ ! -f ./outputdir/bar.txt ]; then
+      echo "ERROR: file bar.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/bar.txt ./outputdir/bar.txt; then
+      echo "ERROR: contents of file bar.txt in rich core does not match the original"
+      return 1
+    fi
+
+    if [ ! -f ./outputdir/bar.log ]; then
+      echo "ERROR: file bar.log is missing from rich core"
+      return 1
+    elif ! diff /tmp/bar.log ./outputdir/bar.log; then
+      echo "ERROR: contents of file bar.log in rich core does not match the original"
+      return 1
+    fi
+
+    if [ ! -f ./outputdir/default.txt ]; then
+      echo "ERROR: file default.txt is missing from rich core"
+      return 1
+    elif ! diff /tmp/default.txt ./outputdir/default.txt; then
+      echo "ERROR: contents of file default.txt in rich core does not match the original"
+      return 1
+    fi
+
+    if [ ! -f ./outputdir/default.foobar ]; then
+      echo "ERROR: file default.foobar is missing from rich core"
+      return 1
+    elif ! diff /tmp/default.foobar ./outputdir/default.foobar; then
+      echo "ERROR: contents of file default.foobar in rich core does not match the original"
+      return 1
+    fi
+
+    if [ ! -f ./outputdir/default.foobar.tar.gz ]; then
+      echo "ERROR: file default.foobar.tar.gz is missing from rich core"
+      return 1
+    elif ! diff /tmp/default.foobar.tar.gz ./outputdir/default.foobar.tar.gz; then
+      echo "ERROR: contents of file default.foobar.tar.gz in rich core does not match the original"
+      return 1
+    fi
+  else
+    echo "ERROR: rich-core-extract failed"
+    return 1
+  fi
+
+  return 0
 }
 
 ### MAIN ###
@@ -336,57 +336,57 @@ EOF
 mkdir -p /etc/rich-core
 
 if [ -f ${DEFAULT_EXTRAS_FILE} ]; then
-    echo "Backup original ${DEFAULT_EXTRAS_FILE}"
-    cp -p ${DEFAULT_EXTRAS_FILE} ${DEFAULT_EXTRAS_FILE}.bak
+  echo "Backup original ${DEFAULT_EXTRAS_FILE}"
+  cp -p ${DEFAULT_EXTRAS_FILE} ${DEFAULT_EXTRAS_FILE}.bak
 fi
 
 echo "Rich core extra files: Test case 1"
 if test_case_1; then
-    echo "Test case 1 PASSED"
+  echo "Test case 1 PASSED"
 else
-    echo "Test case 1 FAILED"
-    ret=1
+  echo "Test case 1 FAILED"
+  ret=1
 fi
 
 echo "Rich core extra files: Test case 2"
 if test_case_2; then
-    echo "Test case 2 PASSED"
+  echo "Test case 2 PASSED"
 else
-    echo "Test case 2 FAILED"
-    ret=1
+  echo "Test case 2 FAILED"
+  ret=1
 fi
 
 echo "Rich core extra files: Test case 3"
 if test_case_3; then
-    echo "Test case 3 PASSED"
+  echo "Test case 3 PASSED"
 else
-    echo "Test case 3 FAILED"
-    ret=1
+  echo "Test case 3 FAILED"
+  ret=1
 fi
 
 echo "Rich core extra files: Test case 4"
 if test_case_4; then
-    echo "Test case 4 PASSED"
+  echo "Test case 4 PASSED"
 else
-    echo "Test case 4 FAILED"
-    ret=1
+  echo "Test case 4 FAILED"
+  ret=1
 fi
 
 echo "Rich core extra files: Test case 5"
 if test_case_5; then
-    echo "Test case 5 PASSED"
+  echo "Test case 5 PASSED"
 else
-    echo "Test case 5 FAILED"
-    ret=1
+  echo "Test case 5 FAILED"
+  ret=1
 fi
 
 # clean created files and directories
 rm -fr ${DEFAULT_EXTRAS_FILE} ${EXTRAS_FILE} ./outputdir /tmp/foo.txt /tmp/bar.txt /tmp/bar.log /tmp/default.txt /tmp/default.foobar /tmp/default.foobar.tar.gz
 
 if [ -f ${DEFAULT_EXTRAS_FILE}.bak ]; then
-    echo "Restore original ${DEFAULT_EXTRAS_FILE}"
-    cp -p ${DEFAULT_EXTRAS_FILE}.bak ${DEFAULT_EXTRAS_FILE}
-    rm -f ${DEFAULT_EXTRAS_FILE}.bak
+  echo "Restore original ${DEFAULT_EXTRAS_FILE}"
+  cp -p ${DEFAULT_EXTRAS_FILE}.bak ${DEFAULT_EXTRAS_FILE}
+  rm -f ${DEFAULT_EXTRAS_FILE}.bak
 fi
 
 echo "$0 exiting with return value $ret"

--- a/tests/test_extract
+++ b/tests/test_extract
@@ -49,8 +49,8 @@ rm -f ${TESTDATADIR}/*
 echo "Generating binary test data to ${TESTDATADIR}"
 for n in $(seq 4000 1 4200)
 do
-    dd bs=${n} count=1 if=/dev/urandom of=${TESTDATADIR}/data${n}.bin > /dev/null 2>&1
-    echo "${TESTDATADIR}/data${n}.bin" >> /etc/rich-core/sleep.extras
+  dd bs=${n} count=1 if=/dev/urandom of=${TESTDATADIR}/data${n}.bin > /dev/null 2>&1
+  echo "${TESTDATADIR}/data${n}.bin" >> /etc/rich-core/sleep.extras
 done
 
 echo "Generating text test data to ${TESTDATADIR}"
@@ -61,15 +61,15 @@ echo -e "\nThis is the last line of file FILENAME" > ${TESTDATADIR}/lastline.txt
 # generate small text extra files
 for n in $(seq 0 1 20)
 do
-    dd bs=1 count=${n} if=${TESTDATADIR}/template.txt of=${TESTDATADIR}/data${n}.txt 2>/dev/null
-    echo "${TESTDATADIR}/data${n}.txt" >> /etc/rich-core/sleep.extras
+  dd bs=1 count=${n} if=${TESTDATADIR}/template.txt of=${TESTDATADIR}/data${n}.txt 2>/dev/null
+  echo "${TESTDATADIR}/data${n}.txt" >> /etc/rich-core/sleep.extras
 done
 
 # generate text extra files of different size
 for n in $(seq 3900 1 4100)
 do
-    dd bs=${n} count=1 if=${TESTDATADIR}/template.txt 2>/dev/null | cat - ${TESTDATADIR}/lastline.txt | sed -e "s|FILENAME|${TESTDATADIR}/data${n}.txt|" > ${TESTDATADIR}/data${n}.txt
-    echo "${TESTDATADIR}/data${n}.txt" >> /etc/rich-core/sleep.extras
+  dd bs=${n} count=1 if=${TESTDATADIR}/template.txt 2>/dev/null | cat - ${TESTDATADIR}/lastline.txt | sed -e "s|FILENAME|${TESTDATADIR}/data${n}.txt|" > ${TESTDATADIR}/data${n}.txt
+  echo "${TESTDATADIR}/data${n}.txt" >> /etc/rich-core/sleep.extras
 done
 
 echo "Listing the contents of ${TESTDATADIR}"
@@ -84,19 +84,19 @@ echo "[---rich-core: coredump---]" | cat - ${coredump} | /usr/sbin/rich-core-dum
 richcore=$(find /var/cache/core-dumps -type f -name sleep*.rcore.lzo)
 
 if [ -f "${richcore}" ]; then
-    echo "copying ${richcore} to /usr/share/sp-rich-core-tests/extract_test.rcore.lzo"
-    cp ${richcore} /usr/share/sp-rich-core-tests/extract_test.rcore.lzo
+  echo "copying ${richcore} to /usr/share/sp-rich-core-tests/extract_test.rcore.lzo"
+  cp ${richcore} /usr/share/sp-rich-core-tests/extract_test.rcore.lzo
 else
-    echo "ERROR: No rich core found"
-    RET=1
+  echo "ERROR: No rich core found"
+  RET=1
 fi
 
 # extract rich core
 rm -fr ${EXTRACTDIR}
 echo "Extracting ${richcore} to ${EXTRACTDIR}"
 if ! /usr/bin/rich-core-extract ${richcore} ${EXTRACTDIR}; then
-    echo "ERROR: rich-core-extract failed"
-    RET=1
+  echo "ERROR: rich-core-extract failed"
+  RET=1
 fi
 
 echo "Listing the contents of ${EXTRACTDIR}"
@@ -106,19 +106,19 @@ echo "--------"
 echo "Checking files in extracted rich core"
 for orig in $(find ${TESTDATADIR} -type f \( -name 'data*.bin' -o -name 'data*.txt' \))
 do
-    name=$(basename ${orig})
-    if [ -f ${EXTRACTDIR}/${name} ]; then
-	if diff -q ${orig} ${EXTRACTDIR}/${name}; then
-	    :
-	    #echo "Test passed with file ${name}"
-	else
-	    echo "ERROR: Files ${orig} and ${EXTRACTDIR}/${name} differ"
-	    RET=1
-	fi
+  name=$(basename ${orig})
+  if [ -f ${EXTRACTDIR}/${name} ]; then
+    if diff -q ${orig} ${EXTRACTDIR}/${name}; then
+      :
+      #echo "Test passed with file ${name}"
     else
-	echo "ERROR: ${EXTRACTDIR}/${name} : no such file"
-	RET=1
+      echo "ERROR: Files ${orig} and ${EXTRACTDIR}/${name} differ"
+      RET=1
     fi
+  else
+    echo "ERROR: ${EXTRACTDIR}/${name} : no such file"
+    RET=1
+  fi
 done
 
 # clean test data and extracted data
@@ -128,8 +128,8 @@ rm -fr ${EXTRACTDIR}
 rm -f /usr/share/sp-rich-core-tests/extract_test.rcore.lzo
 
 if [ $RET -eq 0 ]; then
-    echo "rich-core-extract test PASSED"
+  echo "rich-core-extract test PASSED"
 else
-    echo "rich-core-extract test FAILED"
-    exit 1
+  echo "rich-core-extract test FAILED"
+  exit 1
 fi

--- a/tests/test_script
+++ b/tests/test_script
@@ -38,7 +38,7 @@ _obtain_configuration()
 _parse_arguments()
 {
   while [ $# -ge 1 ]; do
-    case $1 in 
+    case $1 in
       "--do-wait")
       DO_WAIT=true
     esac
@@ -71,8 +71,8 @@ _enable_rich_core_dumper()
 _get_shadow_pid()
 {
   # get pid of 2nd instance
-  ps ax | 
-    grep "$SCRIPT" | 
+  ps ax |
+    grep "$SCRIPT" |
     grep "$SCRIPT_ADDITIONAL_KEY" |
     tr '\n' ' ' |
     sed -e 's/^ *\([0-9]*\) .*$/\1/g'
@@ -152,12 +152,12 @@ sleep 4
 # get its name
 corename=`_get_core_name`.$pid
 
-echo "Corename has to be: $corename" 
+echo "Corename has to be: $corename"
 
 # when core dumping is started, empty file is already exist, and just some time after
-# it will be closed and a real content might be visible, so existing core dump with size 0 
-# just means that 
-# 1) core dumping is yet processing 
+# it will be closed and a real content might be visible, so existing core dump with size 0
+# just means that
+# 1) core dumping is yet processing
 # or
 # 2) something going wrong
 
@@ -206,7 +206,7 @@ if [ -e $corename ]; then
     ret=1
   fi
 
-else 
+else
   echo "Core dump does not exist"
 
   # change return value

--- a/tests/test_whiteblacklist
+++ b/tests/test_whiteblacklist
@@ -34,51 +34,51 @@ CORE_DUMPS_DIR=/var/cache/core-dumps/
 EXPECTED_CORE=0
 
 _setup_case1() {
-    EXPECTED_CORE=1
-    cat > $COMMANDS_FILE <<EOF
+  EXPECTED_CORE=1
+  cat > $COMMANDS_FILE <<EOF
 /bin/sleep 60
 EOF
-    cat > $WHITELIST_FILE <<EOF
+  cat > $WHITELIST_FILE <<EOF
 sleep
 dummy
 EOF
-    rm -f $BLACKLIST_FILE
+  rm -f $BLACKLIST_FILE
 }
 
 _setup_case2() {
-    EXPECTED_CORE=0
-    cat > $COMMANDS_FILE <<EOF
+  EXPECTED_CORE=0
+  cat > $COMMANDS_FILE <<EOF
 /bin/sleep 60
 EOF
-    rm -f $WHITELIST_FILE
-    cat > $BLACKLIST_FILE <<EOF
-foobar  
-sleep  
+  rm -f $WHITELIST_FILE
+  cat > $BLACKLIST_FILE <<EOF
+foobar
+sleep
 EOF
 }
 
 _setup_case3() {
-    EXPECTED_CORE=1
-    cat > $COMMANDS_FILE <<EOF
+  EXPECTED_CORE=1
+  cat > $COMMANDS_FILE <<EOF
 /bin/sleep 60
 EOF
-    cat > $WHITELIST_FILE <<EOF
-  dummy 
-  sleep 
+  cat > $WHITELIST_FILE <<EOF
+  dummy
+  sleep
 EOF
-    cat > $BLACKLIST_FILE <<EOF
+  cat > $BLACKLIST_FILE <<EOF
 sleeper
 foobar
 EOF
 }
 
 _setup_case4() {
-    EXPECTED_CORE=1
-    cat > $COMMANDS_FILE <<EOF
+  EXPECTED_CORE=1
+  cat > $COMMANDS_FILE <<EOF
 /bin/sleep 60
 EOF
-    rm -f $WHITELIST_FILE
-    cat > $BLACKLIST_FILE <<EOF
+  rm -f $WHITELIST_FILE
+  cat > $BLACKLIST_FILE <<EOF
 sleeper
 foobar
 EOF
@@ -87,33 +87,33 @@ EOF
 _run_test_case() {
   cat $COMMANDS_FILE | while read cmd
   do
- 	EXE=$(basename ${cmd%% *})
- 	$cmd&
- 	PID=$!
+   EXE=$(basename ${cmd%% *})
+   $cmd&
+   PID=$!
 
- 	sleep 1
- 	# send signal causing core dump and wait rich core to be created
- 	kill -11 $PID
- 	sleep 30
-	
-	if ls $CORE_DUMPS_DIR | grep -qe "$EXE-.*-$PID\.rcore\.lzo"; then
-	  if [ "$EXPECTED_CORE" == "1" ]; then
-		echo "PASSED: command $cmd"
-	  else
-		echo "FAILED: command $cmd" >&2
-		touch /tmp/richcoretest_failed
-	  fi
-	else
-	  if [ "$EXPECTED_CORE" == "0" ]; then
-		echo "PASSED: command $cmd"
-	  else
-		echo "FAILED: command $cmd" >&2
-		touch /tmp/richcoretest_failed
- 	  fi
-	fi
+   sleep 1
+   # send signal causing core dump and wait rich core to be created
+   kill -11 $PID
+   sleep 30
 
-	# cleanup (possible) core
-	rm -f $CORE_DUMPS_DIR/$EXE*$PID.rcore.lzo
+  if ls $CORE_DUMPS_DIR | grep -qe "$EXE-.*-$PID\.rcore\.lzo"; then
+    if [ "$EXPECTED_CORE" == "1" ]; then
+      echo "PASSED: command $cmd"
+    else
+      echo "FAILED: command $cmd" >&2
+      touch /tmp/richcoretest_failed
+    fi
+  else
+    if [ "$EXPECTED_CORE" == "0" ]; then
+      echo "PASSED: command $cmd"
+    else
+      echo "FAILED: command $cmd" >&2
+      touch /tmp/richcoretest_failed
+     fi
+  fi
+
+  # cleanup (possible) core
+  rm -f $CORE_DUMPS_DIR/$EXE*$PID.rcore.lzo
   done
 }
 
@@ -126,18 +126,18 @@ rm -f /tmp/richcoretest_failed
 
 # check core dir exists
 if [ ! -d "$CORE_DUMPS_DIR" ]; then
-    echo "Core dump directory $CORE_DUMPS_DIR does not exists"
-    exit 2
+  echo "Core dump directory $CORE_DUMPS_DIR does not exists"
+  exit 2
 fi
 
 # backup original whitelist file
 if [ -e "$WHITELIST_FILE" ]; then
-    mv $WHITELIST_FILE $WHITELIST_FILE_BAK
+  mv $WHITELIST_FILE $WHITELIST_FILE_BAK
 fi
 
 # backup original blacklist file
 if [ -e "$BLACKLIST_FILE" ]; then
-    mv $BLACKLIST_FILE $BLACKLIST_FILE_BAK
+  mv $BLACKLIST_FILE $BLACKLIST_FILE_BAK
 fi
 
 echo "Starting white / black list test. Make sure you have crash report autoupload disabled"
@@ -159,20 +159,20 @@ _run_test_case
 
 # restore original whitelist
 if [ -e "$WHITELIST_FILE_BAK" ]; then
-    mv $WHITELIST_FILE_BAK $WHITELIST_FILE
+  mv $WHITELIST_FILE_BAK $WHITELIST_FILE
 else
-    rm -f $WHITELIST_FILE
+  rm -f $WHITELIST_FILE
 fi
 
 # restore original blacklist
 if [ -e "$BLACKLIST_FILE_BAK" ]; then
-    mv $BLACKLIST_FILE_BAK $BLACKLIST_FILE
+  mv $BLACKLIST_FILE_BAK $BLACKLIST_FILE
 else
-    rm -f $BLACKLIST_FILE
+  rm -f $BLACKLIST_FILE
 fi
 
 if [ -e /tmp/richcoretest_failed ]; then
-    ret=1
+  ret=1
 fi
 
 rm -f $COMMANDS_FILE


### PR DESCRIPTION
Since some devices have quite small root partition, it wasn't possible to grab a core dump from e.g. lipstick, since it simply wouldn't fit.

- According to a new config option, use `/home/.crash-reporter/core-dumps` for storing core dump
  - Requires home partition to be mounted
  - Creates the target folder and sets permissions
  - Endurance and oneshots are still always stored to `/var/cache/core-dumps`
- Fix compiler warnings, including misleading whitespace
- Match the key exactly when reading config
  - Previous would match substrings as well
- Optimise reading config values when set in user and system config
- Clean up spec

Requires https://github.com/sailfishos/crash-reporter/pull/59